### PR TITLE
Rework rendering: Change instead of Action, remove Actionw, allow property identity.

### DIFF
--- a/domic/android/src/main/java/com/lyft/domic/android/AndroidCompoundButton.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/AndroidCompoundButton.kt
@@ -2,16 +2,15 @@ package com.lyft.domic.android
 
 import com.jakewharton.rxbinding2.widget.RxCompoundButton
 import com.lyft.domic.android.annotations.MutatedByFramework
+import com.lyft.domic.android.rendering.mapToChange
 import com.lyft.domic.api.Button
 import com.lyft.domic.api.CompoundButton
 import com.lyft.domic.api.rendering.Renderer
 import com.lyft.domic.api.subscribe
 import com.lyft.domic.util.distinctUntilChanged
 import io.reactivex.Observable
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.android.schedulers.AndroidSchedulers.*
+import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
 import io.reactivex.disposables.Disposable
-import io.reactivex.functions.Action
 import java.util.concurrent.atomic.AtomicReferenceArray
 
 class AndroidCompoundButton(
@@ -41,7 +40,7 @@ class AndroidCompoundButton(
 
         override fun checked(checkedValues: Observable<Boolean>): Disposable = checkedValues
                 .distinctUntilChanged(state, STATE_INDEX_CHECKED)
-                .map { Action { realCompoundButton.isChecked = it } }
+                .mapToChange(realCompoundButton, STATE_INDEX_CHECKED) { realCompoundButton.isChecked = it }
                 .subscribe(renderer::render)
     }
 

--- a/domic/android/src/main/java/com/lyft/domic/android/AndroidEditText.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/AndroidEditText.kt
@@ -1,5 +1,6 @@
 package com.lyft.domic.android
 
+import com.lyft.domic.android.rendering.mapToChange
 import com.lyft.domic.api.EditText
 import com.lyft.domic.api.TextView
 import com.lyft.domic.api.rendering.Renderer
@@ -7,13 +8,16 @@ import com.lyft.domic.api.subscribe
 import com.lyft.domic.util.distinctUntilChanged
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
-import io.reactivex.functions.Action
 import java.util.concurrent.atomic.AtomicReferenceArray
 
 class AndroidEditText(
         private val realEditText: android.widget.EditText,
         private val renderer: Renderer
 ) : EditText {
+
+    companion object {
+        private const val STATE_INDEX_SELECTION = 0
+    }
 
     private val asTextView: TextView = AndroidTextView(realEditText, renderer)
     private val state = AtomicReferenceArray<Any>(1)
@@ -26,8 +30,8 @@ class AndroidEditText(
 
         override fun selection(selectionValues: Observable<Int>): Disposable {
             return selectionValues
-                    .distinctUntilChanged(state, 0)
-                    .map { Action { realEditText.setSelection(it) } }
+                    .distinctUntilChanged(state, STATE_INDEX_SELECTION)
+                    .mapToChange(realEditText, STATE_INDEX_SELECTION) { realEditText.setSelection(it) }
                     .subscribe(renderer::render)
         }
     }

--- a/domic/android/src/main/java/com/lyft/domic/android/AndroidTextView.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/AndroidTextView.kt
@@ -2,6 +2,7 @@ package com.lyft.domic.android
 
 import com.jakewharton.rxbinding2.widget.RxTextView
 import com.lyft.domic.android.annotations.MutatedByFramework
+import com.lyft.domic.android.rendering.mapToChange
 import com.lyft.domic.api.TextView
 import com.lyft.domic.api.View
 import com.lyft.domic.api.rendering.Renderer
@@ -10,7 +11,6 @@ import com.lyft.domic.util.distinctUntilChanged
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
 import io.reactivex.disposables.Disposable
-import io.reactivex.functions.Action
 import java.util.concurrent.atomic.AtomicReferenceArray
 
 class AndroidTextView(
@@ -48,7 +48,7 @@ class AndroidTextView(
 
         override fun text(textValues: Observable<out CharSequence>): Disposable = textValues
                 .distinctUntilChanged(state, STATE_INDEX_TEXT)
-                .map { Action { realTextView.text = it } }
+                .mapToChange(realTextView, STATE_INDEX_TEXT) { realTextView.text = it }
                 .subscribe(renderer::render)
     }
 

--- a/domic/android/src/main/java/com/lyft/domic/android/AndroidView.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/AndroidView.kt
@@ -1,6 +1,7 @@
 package com.lyft.domic.android
 
 import com.jakewharton.rxbinding2.view.RxView
+import com.lyft.domic.android.rendering.mapToChange
 import com.lyft.domic.api.View
 import com.lyft.domic.api.rendering.Renderer
 import com.lyft.domic.api.subscribe
@@ -8,13 +9,21 @@ import com.lyft.domic.util.distinctUntilChanged
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
 import io.reactivex.disposables.Disposable
-import io.reactivex.functions.Action
 import java.util.concurrent.atomic.AtomicReferenceArray
 
 class AndroidView(
         private val realView: android.view.View,
         private val renderer: Renderer
 ) : View {
+
+    companion object {
+        private const val STATE_INDEX_ACTIVATED = 0
+        private const val STATE_INDEX_ALPHA = 1
+        private const val STATE_INDEX_ENABLED = 2
+        private const val STATE_INDEX_FOCUSABLE = 3
+        private const val STATE_INDEX_FOCUSABLE_IN_TOUCH_MODE = 4
+        private const val STATE_INDEX_VISIBLE = 5
+    }
 
     private val state = AtomicReferenceArray<Any>(6)
 
@@ -46,50 +55,48 @@ class AndroidView(
 
         override fun activated(activatedValues: Observable<Boolean>): Disposable {
             return activatedValues
-                    .distinctUntilChanged(state, 0)
-                    .map { Action { realView.isActivated = it } }
+                    .distinctUntilChanged(state, STATE_INDEX_ACTIVATED)
+                    .mapToChange(realView, STATE_INDEX_ACTIVATED) { realView.isActivated = it }
                     .subscribe(renderer::render)
         }
 
         override fun alpha(alphaValues: Observable<Float>): Disposable {
             return alphaValues
-                    .distinctUntilChanged(state, 1)
-                    .map { Action { realView.alpha = it } }
+                    .distinctUntilChanged(state, STATE_INDEX_ALPHA)
+                    .mapToChange(realView, STATE_INDEX_ALPHA) { realView.alpha = it }
                     .subscribe(renderer::render)
         }
 
         override fun enabled(enabledValues: Observable<Boolean>): Disposable {
             return enabledValues
-                    .distinctUntilChanged(state, 2)
-                    .map { Action { realView.isEnabled = it } }
+                    .distinctUntilChanged(state, STATE_INDEX_ENABLED)
+                    .mapToChange(realView, STATE_INDEX_ENABLED) { realView.isEnabled = it }
                     .subscribe(renderer::render)
         }
 
         override fun focusable(focusableValues: Observable<Boolean>): Disposable {
             return focusableValues
-                    .distinctUntilChanged(state, 3)
-                    .map { Action { realView.isFocusable = it } }
+                    .distinctUntilChanged(state, STATE_INDEX_FOCUSABLE)
+                    .mapToChange(realView, STATE_INDEX_FOCUSABLE) { realView.isFocusable = it }
                     .subscribe(renderer::render)
         }
 
         override fun focusableInTouchMode(focusableInTouchModeValues: Observable<Boolean>): Disposable {
             return focusableInTouchModeValues
-                    .distinctUntilChanged(state, 4)
-                    .map { Action { realView.isFocusableInTouchMode = it } }
+                    .distinctUntilChanged(state, STATE_INDEX_FOCUSABLE_IN_TOUCH_MODE)
+                    .mapToChange(realView, STATE_INDEX_FOCUSABLE_IN_TOUCH_MODE) { realView.isFocusableInTouchMode = it }
                     .subscribe(renderer::render)
         }
 
         override fun visibility(visibilityValues: Observable<View.Visibility>): Disposable {
             return visibilityValues
-                    .distinctUntilChanged(state, 5)
-                    .map {
-                        Action {
-                            @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
-                            realView.visibility = when (it) {
-                                View.Visibility.GONE -> android.view.View.GONE
-                                View.Visibility.INVISIBLE -> android.view.View.INVISIBLE
-                                View.Visibility.VISIBLE -> android.view.View.VISIBLE
-                            }
+                    .distinctUntilChanged(state, STATE_INDEX_VISIBLE)
+                    .mapToChange(realView, STATE_INDEX_VISIBLE) {
+                        @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
+                        realView.visibility = when (it) {
+                            View.Visibility.GONE -> android.view.View.GONE
+                            View.Visibility.INVISIBLE -> android.view.View.INVISIBLE
+                            View.Visibility.VISIBLE -> android.view.View.VISIBLE
                         }
                     }
                     .subscribe(renderer::render)

--- a/domic/android/src/main/java/com/lyft/domic/android/rendering/AndroidRenderer.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/rendering/AndroidRenderer.kt
@@ -3,46 +3,31 @@ package com.lyft.domic.android.rendering
 import android.os.Looper
 import android.support.annotation.MainThread
 import android.view.Choreographer
+import com.lyft.domic.api.rendering.Change
 import com.lyft.domic.api.rendering.Renderer
 import io.reactivex.Observable
 import io.reactivex.Scheduler
 import io.reactivex.disposables.Disposable
-import io.reactivex.functions.Action
 import io.reactivex.schedulers.Schedulers
+import java.util.*
 import java.util.concurrent.Callable
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit.MILLISECONDS
-import java.util.concurrent.atomic.AtomicInteger
 
+/**
+ * It is expected for the application to maintain a singleton of [AndroidRenderer]
+ * to optimize resource consumption.
+ */
 class AndroidRenderer(
         private val choreographer: Choreographer = Choreographer.getInstance(),
-        timeScheduler: Scheduler = Schedulers.computation(),
+        private val timeScheduler: Scheduler = Schedulers.computation(),
         bufferTimeWindowMs: Long = 8, // We'll adjust if needed.
-        private val buffer: RenderingBuffer<Action> = RenderingBufferImpl(),
+        private val buffer: RenderingBuffer<Change> = RenderingBufferImpl(),
         private val mainThreadChecker: Callable<Boolean> = Callable { Looper.myLooper() == Looper.getMainLooper() }
 ) : Renderer {
 
-    companion object {
-        private val EMPTY_ACTION = Action { }
-        private val INSTANCE by lazy { AndroidRenderer() }
-
-        fun getInstance(): AndroidRenderer = INSTANCE
-    }
-
-    // TODO make a pool of objects similar to Message.obtain() to reduce allocations.
-    internal class Actionw(private val streamId: Int, private val source: Action) : Action {
-
-        override fun run() = source.run()
-
-        override fun equals(other: Any?): Boolean =
-                other === this
-                        ||
-                        (other?.hashCode() == streamId && other is Actionw)
-
-        override fun hashCode() = streamId
-    }
-
-    private val streamIdGenerator = AtomicInteger()
-
+    private val streamDisposables: MutableCollection<StreamDisposable> = ConcurrentLinkedQueue()
     private val disposable: Disposable
 
     init {
@@ -52,30 +37,35 @@ class AndroidRenderer(
                 .map { buffer.getAndSwap() }
                 .subscribe { bufferToRender ->
                     choreographer.postFrameCallback {
-                        bufferToRender.forEach { it.run() }
-
-                        // Make sure we don't synchronize on Main Thread.
-                        timeScheduler.scheduleDirect { buffer.recycle(bufferToRender) }
+                        renderBuffer(bufferToRender)
                     }
                 }
     }
 
-    override fun render(actions: Observable<Action>): Disposable {
-        val streamId = streamIdGenerator.incrementAndGet()
+    private fun renderBuffer(bufferToRender: Collection<Change>) {
+        bufferToRender.forEach { change -> change.perform() }
 
-        val disposable = actions.subscribe { action ->
-            buffer.addOrReplace(Actionw(streamId, action))
+        // Make sure we don't synchronize on Main Thread.
+        timeScheduler.scheduleDirect {
+            streamDisposables.forEach { streamDisposable ->
+                bufferToRender.forEach { change -> streamDisposable.releaseChange(change) }
+            }
+
+            buffer.recycle(bufferToRender)
+        }
+    }
+
+    override fun render(changes: Observable<out Change>): Disposable {
+        val streamDisposable = StreamDisposable()
+
+        val disposable = changes.subscribe { change ->
+            buffer.addOrReplace(change)
+            streamDisposable.trackChange(change)
         }
 
-        return ActionStreamDisposable(
-                Actionw(
-                        streamId,
-
-                        /** We don't need to maintain reference to actual action because equals will check streamId. */
-                        EMPTY_ACTION
-                ),
-                disposable
-        )
+        streamDisposable.source = disposable
+        streamDisposables.add(streamDisposable)
+        return streamDisposable
     }
 
     /**
@@ -89,21 +79,32 @@ class AndroidRenderer(
             throw IllegalStateException("Must be called on correct thread (Main Thread if used with default mainThreadChecker).")
         }
 
-        val currentBuffer = buffer.getAndSwap()
-
-        currentBuffer.forEach { it.run() }
-
-        buffer.recycle(currentBuffer)
+        renderBuffer(buffer.getAndSwap())
     }
 
     override fun shutdown() = disposable.dispose()
 
-    private inner class ActionStreamDisposable(val actionw: Actionw, val source: Disposable) : Disposable {
+    private inner class StreamDisposable : Disposable {
+
+        // Most of the time it'll hold 1 change at a time since we render each property's stream of values separately.
+        // TODO pool of sets.
+        private val changes: MutableSet<Change> = Collections.newSetFromMap(ConcurrentHashMap<Change, Boolean>(1))
+
+        lateinit var source: Disposable
+
+        fun trackChange(change: Change) {
+            changes.add(change)
+        }
+
         override fun isDisposed() = source.isDisposed
 
         override fun dispose() {
-            buffer.remove(actionw)
+            buffer.remove(changes)
             source.dispose()
+        }
+
+        fun releaseChange(change: Change) {
+            changes.remove(change)
         }
     }
 }

--- a/domic/android/src/main/java/com/lyft/domic/android/rendering/RenderingAction.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/rendering/RenderingAction.kt
@@ -1,0 +1,28 @@
+package com.lyft.domic.android.rendering
+
+import com.lyft.domic.api.rendering.Change
+import io.reactivex.Observable
+
+/**
+ * Abstracts object property change and implements equals in a way that matches pro
+ */
+internal abstract class AndroidChange(private val obj: Any, private val propertyId: Int) : Change {
+
+    override fun equals(other: Any?) = other is AndroidChange
+            &&
+            other.obj === this.obj
+            &&
+            other.propertyId == this.propertyId
+
+    override fun hashCode() = obj.hashCode() + propertyId
+
+    override fun toString() = "AndroidChange(obj = ${obj.javaClass}(${obj.hashCode()}), propertyId = $propertyId)"
+}
+
+internal inline fun <T> Observable<T>.mapToChange(obj: Any, propertyId: Int, crossinline func: (T) -> Unit): Observable<out Change> = map { value ->
+    object : AndroidChange(obj, propertyId) {
+        override fun perform() {
+            func.invoke(value)
+        }
+    }
+}

--- a/domic/android/src/main/java/com/lyft/domic/android/rendering/RenderingBuffer.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/rendering/RenderingBuffer.kt
@@ -43,6 +43,11 @@ interface RenderingBuffer<T> {
     fun remove(item: T)
 
     /**
+     * Removes items from *current* underlying buffer. Relies on item's [equals].
+     */
+    fun remove(items: Collection<T>)
+
+    /**
      * Recycles used buffer into internal pool, it's illegal to use buffer after recycling.
      */
     fun recycle(buffer: Collection<T>)

--- a/domic/android/src/main/java/com/lyft/domic/android/rendering/RenderingBufferImpl.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/rendering/RenderingBufferImpl.kt
@@ -39,6 +39,12 @@ internal class RenderingBufferImpl<T> : RenderingBuffer<T> {
         }
     }
 
+    override fun remove(items: Collection<T>) {
+        lock.writeLock().withLock {
+            currentBuffer.removeAll(items)
+        }
+    }
+
     override fun recycle(buffer: Collection<T>) {
         lock.writeLock().withLock {
             buffer as MutableCollection<T>

--- a/domic/android/src/test/java/com/lyft/domic/android/rendering/AndroidRendererTest.kt
+++ b/domic/android/src/test/java/com/lyft/domic/android/rendering/AndroidRendererTest.kt
@@ -1,16 +1,17 @@
 package com.lyft.domic.android.rendering
 
 import android.view.Choreographer
+import com.lyft.domic.api.rendering.Change
 import com.lyft.domic.api.rendering.Renderer
 import com.nhaarman.mockito_kotlin.*
 import io.reactivex.Observable
-import io.reactivex.functions.Action
 import io.reactivex.schedulers.TestScheduler
-import junit.framework.Assert.fail
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.fail
 import org.junit.Test
 import java.util.concurrent.Callable
 import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent.atomic.AtomicBoolean
 
 class AndroidRendererTest {
 
@@ -25,30 +26,25 @@ class AndroidRendererTest {
             RenderingBufferImpl(),
             mainThreadChecker
     )
-    private val actions = listOf<Action>(mock(), mock(), mock(), mock())
+    private val changes = listOf<Change>(mock(), mock(), mock(), mock())
 
     @Test
-    fun postsActionsToChoreographer() {
+    fun postsChangesToChoreographer() {
         whenever(choreographer.postFrameCallback(any())).then { invocation ->
             (invocation.arguments[0] as Choreographer.FrameCallback)
                     .doFrame(0)
         }
 
-        renderer.render(Observable.fromIterable(actions))
+        renderer.render(Observable.fromIterable(changes))
 
         timeScheduler.advanceTimeBy(bufferTimeWindow, MILLISECONDS)
 
-        actions
-                // All actions in same stream must be dismissed in favor of the last one.
-                .take(actions.size - 1)
-                .forEach { action -> verify(action, never()).run() }
-
-        verify(actions.last(), times(1)).run()
+        changes.forEach { change -> verify(change).perform() }
     }
 
     @Test
-    fun buffersActionsInSingleChoreographerCallWithinTimeWindow() {
-        actions.forEach { action -> renderer.render(Observable.just(action)) }
+    fun buffersChangesInSingleChoreographerCallWithinTimeWindow() {
+        changes.forEach { change -> renderer.render(Observable.just(change)) }
 
         timeScheduler.advanceTimeBy(bufferTimeWindow, MILLISECONDS)
 
@@ -57,61 +53,98 @@ class AndroidRendererTest {
     }
 
     @Test
-    fun executesActionsBufferedInSingleChoreographerCallWithinTimeWindow() {
+    fun executesChangesBufferedInSingleChoreographerCallWithinTimeWindow() {
         whenever(choreographer.postFrameCallback(any())).then { invocation ->
             (invocation.arguments[0] as Choreographer.FrameCallback)
                     .doFrame(0)
         }
 
-        actions.forEach { action -> renderer.render(Observable.just(action)) }
+        changes.forEach { change -> renderer.render(Observable.just(change)) }
         timeScheduler.advanceTimeBy(bufferTimeWindow, MILLISECONDS)
 
-        actions.forEach { action -> verify(action, times(1)).run() }
+        changes.forEach { change -> verify(change, times(1)).perform() }
     }
 
     @Test
-    fun actionCrossedBufferTimeWindowCausesSeparateChoreographerCall() {
-        actions.forEach { action ->
-            renderer.render(Observable.just(action))
+    fun changeCrossedBufferTimeWindowCausesSeparateChoreographerCall() {
+        changes.forEach { change ->
+            renderer.render(Observable.just(change))
             timeScheduler.advanceTimeBy(bufferTimeWindow, MILLISECONDS)
         }
 
-        verify(choreographer, times(actions.size)).postFrameCallback(any())
+        verify(choreographer, times(changes.size)).postFrameCallback(any())
     }
 
     @Test
-    fun doesNotExecuteOldActionsAgain() {
+    fun doesNotExecuteOldChangesAgain() {
         whenever(choreographer.postFrameCallback(any())).then { invocation ->
             (invocation.arguments[0] as Choreographer.FrameCallback)
                     .doFrame(0)
         }
 
-        val action1 = mock<Action>()
-        renderer.render(Observable.just(action1))
+        val change1 = mock<Change>()
+        renderer.render(Observable.just(change1))
         timeScheduler.advanceTimeBy(bufferTimeWindow, MILLISECONDS)
 
-        verify(action1).run()
+        verify(change1).perform()
 
-        val action2 = mock<Action>()
-        renderer.render(Observable.just(action2))
+        val change2 = mock<Change>()
+        renderer.render(Observable.just(change2))
         timeScheduler.advanceTimeBy(bufferTimeWindow, MILLISECONDS)
 
-        verifyNoMoreInteractions(action1)
-        verify(action1).run()
+        verifyNoMoreInteractions(change1)
+        verify(change1).perform()
     }
 
     @Test
-    fun actionsAreNotExecutedWithoutChoreographerCallback() {
-        actions.forEach { action -> renderer.render(Observable.just(action)) }
+    fun changesAreNotExecutedWithoutChoreographerCallback() {
+        changes.forEach { change -> renderer.render(Observable.just(change)) }
 
         timeScheduler.advanceTimeBy(bufferTimeWindow, MILLISECONDS)
 
-        actions.forEach { action -> verify(action, never()).run() }
+        changes.forEach { change -> verify(change, never()).perform() }
     }
 
     @Test
-    fun actionStreamDisposeRemovesActionFromBuffer() {
-        val disposable = renderer.render(Observable.fromIterable(actions))
+    fun equalChangesInSameStreamAreDebouncedWithinBufferTimeWindow() {
+        whenever(choreographer.postFrameCallback(any())).then { invocation ->
+            (invocation.arguments[0] as Choreographer.FrameCallback)
+                    .doFrame(0)
+        }
+
+        val change1 = TestChange("a")
+        val change2 = TestChange("a")
+
+        renderer.render(Observable.fromIterable(listOf(change1, change2)))
+
+        timeScheduler.advanceTimeBy(bufferTimeWindow, MILLISECONDS)
+
+        assertThat(change1.performed).isFalse()
+        assertThat(change2.performed).isTrue()
+    }
+
+    @Test
+    fun equalChangesInDifferentStreamsAreDebouncedWithinBufferTimeWindow() {
+        whenever(choreographer.postFrameCallback(any())).then { invocation ->
+            (invocation.arguments[0] as Choreographer.FrameCallback)
+                    .doFrame(0)
+        }
+
+        val change1 = TestChange("a")
+        val change2 = TestChange("a")
+
+        renderer.render(Observable.just(change1))
+        renderer.render(Observable.just(change2))
+
+        timeScheduler.advanceTimeBy(bufferTimeWindow, MILLISECONDS)
+
+        assertThat(change1.performed).isFalse()
+        assertThat(change2.performed).isTrue()
+    }
+
+    @Test
+    fun changeStreamDisposeRemovesChangesFromBuffer() {
+        val disposable = renderer.render(Observable.fromIterable(changes))
 
         disposable.dispose()
 
@@ -122,7 +155,7 @@ class AndroidRendererTest {
 
     @Test
     fun renderCurrentBufferThrowsOnWrongThread() {
-        renderer.render(Observable.fromIterable(actions))
+        renderer.render(Observable.fromIterable(changes))
         whenever(mainThreadChecker.call()).thenReturn(false)
 
         try {
@@ -132,22 +165,22 @@ class AndroidRendererTest {
             assertThat(expected).hasMessage("Must be called on correct thread (Main Thread if used with default mainThreadChecker).")
         }
 
-        actions.forEach { action -> verify(action, never()).run() }
+        changes.forEach { change -> verify(change, never()).perform() }
     }
 
     @Test
     fun renderCurrentBufferRenders() {
-        actions.forEach { action -> renderer.render(Observable.just(action)) }
+        changes.forEach { change -> renderer.render(Observable.just(change)) }
         whenever(mainThreadChecker.call()).thenReturn(true)
 
         renderer.renderCurrentBuffer()
 
-        actions.forEach { action -> verify(action).run() }
+        changes.forEach { change -> verify(change).perform() }
     }
 
     @Test
     fun shutdownStopsPostingToChoreographer() {
-        renderer.render(Observable.fromIterable(actions))
+        renderer.render(Observable.fromIterable(changes))
         renderer.shutdown()
         timeScheduler.advanceTimeBy(bufferTimeWindow, MILLISECONDS)
         verify(choreographer, never()).postFrameCallback(any())
@@ -155,5 +188,23 @@ class AndroidRendererTest {
         renderer.render(Observable.just(mock()))
         timeScheduler.advanceTimeBy(bufferTimeWindow, MILLISECONDS)
         verify(choreographer, never()).postFrameCallback(any())
+    }
+
+    class TestChange(private val id: Any) : Change {
+
+        private val performedState = AtomicBoolean()
+
+        val performed: Boolean
+            get() = performedState.get()
+
+        override fun perform() {
+            if (!performedState.compareAndSet(false, true)) {
+                throw IllegalStateException("Change.perform() called second time!")
+            }
+        }
+
+        override fun equals(other: Any?) = other is TestChange && other.id == this.id
+
+        override fun hashCode() = id.hashCode()
     }
 }

--- a/domic/api/src/main/kotlin/com/lyft/domic/api/extensions.kt
+++ b/domic/api/src/main/kotlin/com/lyft/domic/api/extensions.kt
@@ -1,7 +1,9 @@
 package com.lyft.domic.api
 
+import com.lyft.domic.api.rendering.Change
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 
 inline fun <T> Observable<T>.subscribe(crossinline bindFunc: (stream: Observable<T>) -> Disposable): Disposable =
         bindFunc.invoke(this)
+

--- a/domic/api/src/main/kotlin/com/lyft/domic/api/rendering/Change.kt
+++ b/domic/api/src/main/kotlin/com/lyft/domic/api/rendering/Change.kt
@@ -1,0 +1,14 @@
+package com.lyft.domic.api.rendering
+
+/**
+ * Change to be rendered.
+ *
+ * [Renderer] might use [equals] and [hashCode] to compare [Change]s and optimize rendering pipeline based on that.
+ */
+interface Change {
+
+    /**
+     * Called once by [Renderer] on appropriate thread (by default on Main Thread).
+     */
+    fun perform()
+}

--- a/domic/api/src/main/kotlin/com/lyft/domic/api/rendering/Renderer.kt
+++ b/domic/api/src/main/kotlin/com/lyft/domic/api/rendering/Renderer.kt
@@ -2,7 +2,6 @@ package com.lyft.domic.api.rendering
 
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
-import io.reactivex.functions.Action
 
 interface Renderer {
 
@@ -11,16 +10,16 @@ interface Renderer {
      *
      * Implementation can be opinionated on grouping, and/or ordering of execution.
      *
-     * Each action's `Action.run()` will be called once on proper thread (ie Main Thread).
+     * [Renderer] might use [Change.equals] and [Change.hashCode] to compare [Change]s and optimize
+     * rendering pipeline based on that, for example render latest equal [Change] arrived
+     * within same buffering window.
      *
-     * TODO add @param reduce if `true` allows [Renderer] to reduce actions emitted by single [Observable]
-     * to be reduced down to last one within buffering time window thus reducing amount of actions
-     * that need to be rendered.
+     * Each [Change]'s [Change.perform] will be called once on proper thread (Main Thread by default).
      *
      * @return [Disposable] that allows to stop observing the [Observable]. [Renderer] should try
-     * to remove observed but not rendered actions from current buffer.
+     * to remove observed but not yet rendered actions from current buffer.
      */
-    fun render(actions: Observable<Action>): Disposable
+    fun render(changes: Observable<out Change>): Disposable
 
     /**
      * "Renders" what is in the buffer at the moment, blocking the caller thread.

--- a/samples/mvp/src/main/java/com/lyft/domic/samples/mvp/MainActivity.kt
+++ b/samples/mvp/src/main/java/com/lyft/domic/samples/mvp/MainActivity.kt
@@ -19,7 +19,8 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val view = AndroidSignInView(findViewById(android.R.id.content), AndroidRenderer.getInstance())
+        val renderer = AndroidRenderer()
+        val view = AndroidSignInView(findViewById(android.R.id.content), renderer)
 
         disposable += Single
                 .fromCallable { SignInPresenter(view, RealSignInService()) }

--- a/samples/mvvm/src/main/java/com/lyft/domic/samples/mvvm/MainActivity.kt
+++ b/samples/mvvm/src/main/java/com/lyft/domic/samples/mvvm/MainActivity.kt
@@ -19,7 +19,8 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val view = AndroidSignInView(findViewById(android.R.id.content), AndroidRenderer.getInstance())
+        val renderer = AndroidRenderer()
+        val view = AndroidSignInView(findViewById(android.R.id.content), renderer)
 
         disposable += Single
                 .fromCallable { SignInViewModel(view, RealSignInService()) }


### PR DESCRIPTION
This PR significantly improves `Renderer` implementation:

- Multiple active streams can update same `View/Widget.property` and Renderer will still debounce changes within buffer window, before it'll only debounce within same stream
- `Renderer.render()` is now able to render arbitrary changes within same `Observable<Change>` stream without potentially wrong debouncing for unrelated proeprties
- Better debuggability by having `View/Widget` and property state index in `Change` object and its `toString()`
- No additional allocations for `Actionw`
- Less reliance on RxJava types, now we own `Change` interface