### PR TITLE
Use Choreographer as Rendering signal instead of timer

### DIFF
--- a/domic/android/src/main/java/com/lyft/domic/android/rendering/AndroidRenderer.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/rendering/AndroidRenderer.kt
@@ -9,11 +9,11 @@ import io.reactivex.Observable
 import io.reactivex.Scheduler
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
+import io.reactivex.subjects.PublishSubject
 import java.util.*
 import java.util.concurrent.Callable
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.TimeUnit.MILLISECONDS
 
 /**
  * It is expected for the application to maintain a singleton of [AndroidRenderer]
@@ -21,8 +21,7 @@ import java.util.concurrent.TimeUnit.MILLISECONDS
  */
 class AndroidRenderer(
         private val choreographer: Choreographer = Choreographer.getInstance(),
-        private val timeScheduler: Scheduler = Schedulers.computation(),
-        bufferTimeWindowMs: Long = 8, // We'll adjust if needed.
+        private val computationScheduler: Scheduler = Schedulers.computation(),
         private val buffer: RenderingBuffer<Change> = RenderingBufferImpl(),
         private val mainThreadChecker: Callable<Boolean> = Callable { Looper.myLooper() == Looper.getMainLooper() }
 ) : Renderer {
@@ -31,14 +30,34 @@ class AndroidRenderer(
     private val disposable: Disposable
 
     init {
-        disposable = Observable
-                .interval(0, bufferTimeWindowMs, MILLISECONDS, timeScheduler)
-                .filter { buffer.isEmpty() == false }
+        val frameSignal = PublishSubject.create<Unit>()
+
+        val frameCallback = object : Choreographer.FrameCallback {
+            override fun doFrame(frameTimeNanos: Long) {
+                frameSignal.onNext(Unit)
+
+                // Async loop.
+                choreographer.postFrameCallback(this)
+
+                // TODO: Detect foreground state and remove callback if app is in background?
+                // Pros:
+                //      - Domic won't do anything on its own while app is in background.
+                // Cons:
+                //      - Changes pushed to the Renderer will be buffered in memory
+                //        which can lead to OOM in background.
+                //        Android Framework normally renders UI in memory,
+                //        effectively keeping only current state in memory.
+            }
+        }
+
+        choreographer.postFrameCallback(frameCallback)
+
+        disposable = frameSignal
+                .filter { !buffer.isEmpty() }
                 .map { buffer.getAndSwap() }
+                .doOnDispose { choreographer.removeFrameCallback(frameCallback) }
                 .subscribe { bufferToRender ->
-                    choreographer.postFrameCallback {
-                        renderBuffer(bufferToRender)
-                    }
+                    renderBuffer(bufferToRender)
                 }
     }
 
@@ -46,7 +65,7 @@ class AndroidRenderer(
         bufferToRender.forEach { change -> change.perform() }
 
         // Make sure we don't synchronize on Main Thread.
-        timeScheduler.scheduleDirect {
+        computationScheduler.scheduleDirect {
             streamDisposables.forEach { streamDisposable ->
                 bufferToRender.forEach { change -> streamDisposable.releaseChange(change) }
             }

--- a/domic/android/src/main/java/com/lyft/domic/android/rendering/RenderingBuffer.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/rendering/RenderingBuffer.kt
@@ -21,7 +21,7 @@ interface RenderingBuffer<T> {
 
     /**
      * Atomically swaps *current* underlying buffer with another and returns the one that was
-     * *current* before swap.
+     * *current* before the swap.
      *
      * Subsequent reads and writes on this [RenderingBuffer] will work against another buffer
      * until it's swapped.

--- a/domic/android/src/test/java/com/lyft/domic/android/rendering/TestChoreographer.kt
+++ b/domic/android/src/test/java/com/lyft/domic/android/rendering/TestChoreographer.kt
@@ -1,0 +1,33 @@
+package com.lyft.domic.android.rendering
+
+import android.view.Choreographer
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+
+class TestChoreographer {
+
+    // Choreographer is a final class, we can't implement it as interface directly.
+    val choreographer: Choreographer = mock()
+
+    private val currentFrameCallbacks = mutableSetOf<Choreographer.FrameCallback>()
+    private var frameTimeNanos = 0L
+
+    init {
+        whenever(choreographer.postFrameCallback(any())).then { invocation ->
+            currentFrameCallbacks += invocation.arguments.first() as Choreographer.FrameCallback
+            Unit
+        }
+    }
+
+    fun callbacksCount(): Int = currentFrameCallbacks.size
+
+    /**
+     * Simulates call from Android Framework, callbacks are disposed to mimic Framework.
+     */
+    fun simulateCallbacksCall() {
+        val callbacksCopy = HashSet<Choreographer.FrameCallback>(currentFrameCallbacks)
+        currentFrameCallbacks.clear()
+        callbacksCopy.forEach { it.doFrame(frameTimeNanos++) }
+    }
+}


### PR DESCRIPTION
PR refactors `AndroidRenderer` so that it uses `Choreographer` as a signal to swap buffers and render current one effectively swapping and rendering at the device's framerate. 

Previous implementation was also rendering at device's framerate but it had custom time based signal to swap buffers (note that it's not double-buffering, but multi-buffering) but then using Choreographer to post and render the changes. 
Previous implementation could and did post multiple Choreographer callbacks within same frame, new implementation minimizes interactions with Choreographer and also uses less memory by reusing the callback as well as less thread switching.