### PR TITLE
Reimplement sharedDistinctUntilChanged() as RxJava operator

### DIFF
--- a/domic/android/src/main/java/com/lyft/domic/android/AndroidCompoundButton.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/AndroidCompoundButton.kt
@@ -7,7 +7,7 @@ import com.lyft.domic.api.Button
 import com.lyft.domic.api.CompoundButton
 import com.lyft.domic.api.rendering.Renderer
 import com.lyft.domic.api.subscribe
-import com.lyft.domic.util.distinctUntilChanged
+import com.lyft.domic.util.sharedDistinctUntilChanged
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
 import io.reactivex.disposables.Disposable
@@ -39,7 +39,7 @@ class AndroidCompoundButton(
     override val change: CompoundButton.Change = object : CompoundButton.Change, Button.Change by asButton.change {
 
         override fun checked(checkedValues: Observable<Boolean>): Disposable = checkedValues
-                .distinctUntilChanged(state, STATE_INDEX_CHECKED)
+                .sharedDistinctUntilChanged(state, STATE_INDEX_CHECKED)
                 .mapToChange(realCompoundButton, STATE_INDEX_CHECKED) { realCompoundButton.isChecked = it }
                 .subscribe(renderer::render)
     }

--- a/domic/android/src/main/java/com/lyft/domic/android/AndroidEditText.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/AndroidEditText.kt
@@ -5,7 +5,7 @@ import com.lyft.domic.api.EditText
 import com.lyft.domic.api.TextView
 import com.lyft.domic.api.rendering.Renderer
 import com.lyft.domic.api.subscribe
-import com.lyft.domic.util.distinctUntilChanged
+import com.lyft.domic.util.sharedDistinctUntilChanged
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 import java.util.concurrent.atomic.AtomicReferenceArray
@@ -30,7 +30,7 @@ class AndroidEditText(
 
         override fun selection(selectionValues: Observable<Int>): Disposable {
             return selectionValues
-                    .distinctUntilChanged(state, STATE_INDEX_SELECTION)
+                    .sharedDistinctUntilChanged(state, STATE_INDEX_SELECTION)
                     .mapToChange(realEditText, STATE_INDEX_SELECTION) { realEditText.setSelection(it) }
                     .subscribe(renderer::render)
         }

--- a/domic/android/src/main/java/com/lyft/domic/android/AndroidTextView.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/AndroidTextView.kt
@@ -10,7 +10,7 @@ import com.lyft.domic.api.TextView
 import com.lyft.domic.api.View
 import com.lyft.domic.api.rendering.Renderer
 import com.lyft.domic.api.subscribe
-import com.lyft.domic.util.distinctUntilChanged
+import com.lyft.domic.util.sharedDistinctUntilChanged
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
 import io.reactivex.disposables.Disposable
@@ -65,7 +65,7 @@ class AndroidTextView(
 
         override fun text(textValues: Observable<out CharSequence>): Disposable {
             var values: Observable<out CharSequence> = textValues
-                    .distinctUntilChanged(state, STATE_INDEX_TEXT)
+                    .sharedDistinctUntilChanged(state, STATE_INDEX_TEXT)
 
             if (Build.VERSION.SDK_INT >= 28) {
                 values = Observable

--- a/domic/android/src/main/java/com/lyft/domic/android/AndroidView.kt
+++ b/domic/android/src/main/java/com/lyft/domic/android/AndroidView.kt
@@ -5,7 +5,7 @@ import com.lyft.domic.android.rendering.mapToChange
 import com.lyft.domic.api.View
 import com.lyft.domic.api.rendering.Renderer
 import com.lyft.domic.api.subscribe
-import com.lyft.domic.util.distinctUntilChanged
+import com.lyft.domic.util.sharedDistinctUntilChanged
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
 import io.reactivex.disposables.Disposable
@@ -55,42 +55,42 @@ class AndroidView(
 
         override fun activated(activatedValues: Observable<Boolean>): Disposable {
             return activatedValues
-                    .distinctUntilChanged(state, STATE_INDEX_ACTIVATED)
+                    .sharedDistinctUntilChanged(state, STATE_INDEX_ACTIVATED)
                     .mapToChange(realView, STATE_INDEX_ACTIVATED) { realView.isActivated = it }
                     .subscribe(renderer::render)
         }
 
         override fun alpha(alphaValues: Observable<Float>): Disposable {
             return alphaValues
-                    .distinctUntilChanged(state, STATE_INDEX_ALPHA)
+                    .sharedDistinctUntilChanged(state, STATE_INDEX_ALPHA)
                     .mapToChange(realView, STATE_INDEX_ALPHA) { realView.alpha = it }
                     .subscribe(renderer::render)
         }
 
         override fun enabled(enabledValues: Observable<Boolean>): Disposable {
             return enabledValues
-                    .distinctUntilChanged(state, STATE_INDEX_ENABLED)
+                    .sharedDistinctUntilChanged(state, STATE_INDEX_ENABLED)
                     .mapToChange(realView, STATE_INDEX_ENABLED) { realView.isEnabled = it }
                     .subscribe(renderer::render)
         }
 
         override fun focusable(focusableValues: Observable<Boolean>): Disposable {
             return focusableValues
-                    .distinctUntilChanged(state, STATE_INDEX_FOCUSABLE)
+                    .sharedDistinctUntilChanged(state, STATE_INDEX_FOCUSABLE)
                     .mapToChange(realView, STATE_INDEX_FOCUSABLE) { realView.isFocusable = it }
                     .subscribe(renderer::render)
         }
 
         override fun focusableInTouchMode(focusableInTouchModeValues: Observable<Boolean>): Disposable {
             return focusableInTouchModeValues
-                    .distinctUntilChanged(state, STATE_INDEX_FOCUSABLE_IN_TOUCH_MODE)
+                    .sharedDistinctUntilChanged(state, STATE_INDEX_FOCUSABLE_IN_TOUCH_MODE)
                     .mapToChange(realView, STATE_INDEX_FOCUSABLE_IN_TOUCH_MODE) { realView.isFocusableInTouchMode = it }
                     .subscribe(renderer::render)
         }
 
         override fun visibility(visibilityValues: Observable<View.Visibility>): Disposable {
             return visibilityValues
-                    .distinctUntilChanged(state, STATE_INDEX_VISIBLE)
+                    .sharedDistinctUntilChanged(state, STATE_INDEX_VISIBLE)
                     .mapToChange(realView, STATE_INDEX_VISIBLE) {
                         @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
                         realView.visibility = when (it) {

--- a/domic/test/src/main/java/com/lyft/domic/test/TestCompoundButton.kt
+++ b/domic/test/src/main/java/com/lyft/domic/test/TestCompoundButton.kt
@@ -2,7 +2,7 @@ package com.lyft.domic.test
 
 import com.lyft.domic.api.Button
 import com.lyft.domic.api.CompoundButton
-import com.lyft.domic.util.distinctUntilChanged
+import com.lyft.domic.util.sharedDistinctUntilChanged
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 import java.util.concurrent.atomic.AtomicReferenceArray
@@ -30,7 +30,7 @@ class TestCompoundButton : CompoundButton {
         private val state = AtomicReferenceArray<Any>(1)
 
         override fun checked(checkedValues: Observable<Boolean>): Disposable = checkedValues
-                .distinctUntilChanged(state, 0)
+                .sharedDistinctUntilChanged(state, 0)
                 .subscribe(checkedRelay)
     }
 

--- a/domic/test/src/main/java/com/lyft/domic/test/TestEditText.kt
+++ b/domic/test/src/main/java/com/lyft/domic/test/TestEditText.kt
@@ -2,7 +2,7 @@ package com.lyft.domic.test
 
 import com.lyft.domic.api.EditText
 import com.lyft.domic.api.TextView
-import com.lyft.domic.util.distinctUntilChanged
+import com.lyft.domic.util.sharedDistinctUntilChanged
 
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
@@ -34,7 +34,7 @@ class TestEditText : EditText {
 
         override fun selection(selectionValues: Observable<Int>): Disposable =
                 selectionValues
-                        .distinctUntilChanged(state, 0)
+                        .sharedDistinctUntilChanged(state, 0)
                         .subscribe(selectionRelay)
     }
 

--- a/domic/test/src/main/java/com/lyft/domic/test/TestTextView.kt
+++ b/domic/test/src/main/java/com/lyft/domic/test/TestTextView.kt
@@ -2,7 +2,7 @@ package com.lyft.domic.test
 
 import com.lyft.domic.api.TextView
 import com.lyft.domic.api.View
-import com.lyft.domic.util.distinctUntilChanged
+import com.lyft.domic.util.sharedDistinctUntilChanged
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 import java.util.concurrent.atomic.AtomicReferenceArray
@@ -37,7 +37,7 @@ class TestTextView : TextView {
 
         override fun text(textValues: Observable<out CharSequence>): Disposable {
             return textValues
-                    .distinctUntilChanged(state, 0)
+                    .sharedDistinctUntilChanged(state, 0)
                     .subscribe { text ->
                         textChangesRelay.accept(text)
                         textChangeEventsRelay.accept(Any())

--- a/domic/test/src/main/java/com/lyft/domic/test/TestView.kt
+++ b/domic/test/src/main/java/com/lyft/domic/test/TestView.kt
@@ -1,7 +1,7 @@
 package com.lyft.domic.test
 
 import com.lyft.domic.api.View
-import com.lyft.domic.util.distinctUntilChanged
+import com.lyft.domic.util.sharedDistinctUntilChanged
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 import java.util.concurrent.atomic.AtomicReferenceArray
@@ -52,37 +52,37 @@ class TestView : View {
 
         override fun activated(activatedValues: Observable<Boolean>): Disposable {
             return activatedValues
-                    .distinctUntilChanged(state, 0)
+                    .sharedDistinctUntilChanged(state, 0)
                     .subscribe(activatedRelay)
         }
 
         override fun alpha(alphaValues: Observable<Float>): Disposable {
             return alphaValues
-                    .distinctUntilChanged(state, 1)
+                    .sharedDistinctUntilChanged(state, 1)
                     .subscribe(alphaRelay)
         }
 
         override fun enabled(enabledValues: Observable<Boolean>): Disposable {
             return enabledValues
-                    .distinctUntilChanged(state, 2)
+                    .sharedDistinctUntilChanged(state, 2)
                     .subscribe(enabledRelay)
         }
 
         override fun focusable(focusableValues: Observable<Boolean>): Disposable {
             return focusableValues
-                    .distinctUntilChanged(state, 3)
+                    .sharedDistinctUntilChanged(state, 3)
                     .subscribe(focusableRelay)
         }
 
         override fun focusableInTouchMode(focusableInTouchModeValues: Observable<Boolean>): Disposable {
             return focusableInTouchModeValues
-                    .distinctUntilChanged(state, 4)
+                    .sharedDistinctUntilChanged(state, 4)
                     .subscribe(focusableInTouchModeRelay)
         }
 
         override fun visibility(visibilityValues: Observable<View.Visibility>): Disposable {
             return visibilityValues
-                    .distinctUntilChanged(state, 5)
+                    .sharedDistinctUntilChanged(state, 5)
                     .subscribe(visibilityRelay)
         }
     }

--- a/domic/util/src/main/java/com/lyft/domic/util/DistinctUntilChanged.kt
+++ b/domic/util/src/main/java/com/lyft/domic/util/DistinctUntilChanged.kt
@@ -29,7 +29,7 @@ internal class ObservableSharedDistinctUntilChanged<T>(
         source.subscribe(SharedDistinctUntilChangedObserver(actual, sharedState, stateIndex))
     }
 
-    inner class SharedDistinctUntilChangedObserver<T>(
+    class SharedDistinctUntilChangedObserver<T>(
             private val actual: Observer<in T>,
             private val sharedState: AtomicReferenceArray<Any>,
             private val stateIndex: Int

--- a/domic/util/src/main/java/com/lyft/domic/util/DistinctUntilChanged.kt
+++ b/domic/util/src/main/java/com/lyft/domic/util/DistinctUntilChanged.kt
@@ -1,19 +1,97 @@
 package com.lyft.domic.util
 
 import io.reactivex.Observable
+import io.reactivex.ObservableSource
+import io.reactivex.Observer
+import io.reactivex.disposables.Disposable
+import io.reactivex.exceptions.ProtocolViolationException
+import io.reactivex.plugins.RxJavaPlugins
 import java.util.concurrent.atomic.AtomicReferenceArray
 
 /**
- * Similar to [Observable.distinctUntilChanged] but allows to use shared atomic state thus letting Domic handle
- * multiple rx streams updating same property.
+ * Similar to standard [Observable.distinctUntilChanged] but operates on shared atomic state
+ * thus letting Domic handle multiple rx streams consistently updating same property.
+ *
+ * @param sharedState atomic reference array that is used as source of current state when comparison happens.
+ * @param stateIndex index of the item in the array that needs to be used to get current state when comparison happens.
  */
-fun <T> Observable<out T>.distinctUntilChanged(sharedState: AtomicReferenceArray<Any>, index: Int): Observable<T> = switchMap { newValue ->
-    // TODO rewrite as Observable Operator to minimize allocations and implement fusion.
-    val prevValue: Any? = sharedState.get(index)
+fun <T> Observable<T>.sharedDistinctUntilChanged(sharedState: AtomicReferenceArray<Any>, stateIndex: Int): Observable<T> = RxJavaPlugins
+        .onAssembly(ObservableSharedDistinctUntilChanged(this, sharedState, stateIndex))
 
-    if (newValue != prevValue && sharedState.compareAndSet(index, prevValue, newValue)) {
-        Observable.just(newValue)
-    } else {
-        Observable.empty()
+// TODO implement Operator Fusion, looks like required interfaces are internal in RxJava :(
+internal class ObservableSharedDistinctUntilChanged<T>(
+        private val source: ObservableSource<T>,
+        private val sharedState: AtomicReferenceArray<Any>,
+        private val stateIndex: Int
+) : Observable<T>() {
+
+    override fun subscribeActual(actual: Observer<in T>) {
+        source.subscribe(SharedDistinctUntilChangedObserver(actual, sharedState, stateIndex))
     }
+
+    inner class SharedDistinctUntilChangedObserver<T>(
+            private val actual: Observer<in T>,
+            private val sharedState: AtomicReferenceArray<Any>,
+            private val stateIndex: Int
+    ) : Observer<T>, Disposable {
+
+        private var upstream: Disposable? = null
+        var done: Boolean = false
+
+        override fun onSubscribe(disposable: Disposable) {
+            if (validateDisposable(upstream, disposable)) {
+                upstream = disposable
+                actual.onSubscribe(this)
+            }
+        }
+
+        override fun onNext(newValue: T) {
+            if (done) {
+                return
+            }
+
+            val prevValue: Any? = sharedState.get(stateIndex)
+
+            if (newValue != prevValue && sharedState.compareAndSet(stateIndex, prevValue, newValue)) {
+                actual.onNext(newValue)
+            }
+        }
+
+        override fun onComplete() {
+            if (done) {
+                return
+            }
+
+            done = true
+            actual.onComplete()
+        }
+
+        override fun onError(e: Throwable) {
+            if (done) {
+                RxJavaPlugins.onError(e)
+                return
+            }
+
+            done = true
+            actual.onError(e)
+        }
+
+        override fun isDisposed() = upstream!!.isDisposed
+
+        override fun dispose() = upstream!!.dispose()
+    }
+}
+
+private fun validateDisposable(current: Disposable?, new: Disposable?): Boolean {
+    if (new == null) {
+        RxJavaPlugins.onError(NullPointerException("new disposable is null"))
+        return false
+    }
+
+    if (current != null) {
+        new.dispose()
+        RxJavaPlugins.onError(ProtocolViolationException("Disposable is already set"))
+        return false
+    }
+    return true
 }

--- a/domic/util/src/test/java/com/lyft/domic/util/DistinctUntilChangedTest.kt
+++ b/domic/util/src/test/java/com/lyft/domic/util/DistinctUntilChangedTest.kt
@@ -12,7 +12,7 @@ class DistinctUntilChangedTest {
 
         Observable
                 .fromArray("a", "b")
-                .distinctUntilChanged(state, 0)
+                .sharedDistinctUntilChanged(state, 0)
                 .test()
                 .assertResult("a", "b")
     }
@@ -23,7 +23,7 @@ class DistinctUntilChangedTest {
 
         Observable
                 .fromArray("a", "a")
-                .distinctUntilChanged(state, 0)
+                .sharedDistinctUntilChanged(state, 0)
                 .test()
                 .assertResult("a")
     }
@@ -34,19 +34,19 @@ class DistinctUntilChangedTest {
 
         Observable
                 .just("a")
-                .distinctUntilChanged(state, 0)
+                .sharedDistinctUntilChanged(state, 0)
                 .test()
                 .assertResult("a")
 
         Observable
                 .just("a")
-                .distinctUntilChanged(state, 0)
+                .sharedDistinctUntilChanged(state, 0)
                 .test()
                 .assertResult()
 
         Observable
                 .just("b")
-                .distinctUntilChanged(state, 0)
+                .sharedDistinctUntilChanged(state, 0)
                 .test()
                 .assertResult("b")
     }

--- a/domic/util/src/test/java/com/lyft/domic/util/SharedDistinctUntilChangedTest.kt
+++ b/domic/util/src/test/java/com/lyft/domic/util/SharedDistinctUntilChangedTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 import java.lang.Exception
 import java.util.concurrent.atomic.AtomicReferenceArray
 
-class DistinctUntilChangedTest {
+class SharedDistinctUntilChangedTest {
 
     @Test
     fun sharedDistinctUntilChangedEmitsDistinctValues() {


### PR DESCRIPTION
PR refactors `sharedDistinctUntilChanged()` (used to be named `distinctUntilChanged()`) so that it now actually is a proper RxJava operator, rather than a combination of `switchMap`/`just`/`never`.

This results in a better memory and cpu consumption and pretty much minimal required amount of code to do the job implementing RxJava protocols.

The only problem is that I'd like to implement Operator Fusion, but looks like interfaces required for that are `internal` in RxJava:

- `io.reactivex.internal.fuseable.QueueDisposable`
- `io.reactivex.internal.fuseable.QueueFuseable`
- `io.reactivex.internal.fuseable.SimpleQueue`

@akarnokd @vanniktech would really appreciate your review